### PR TITLE
Fix: Member 엔티티의 rank 컬럼 예약어 충돌

### DIFF
--- a/src/main/java/com/repill/backend/member/entity/Member.java
+++ b/src/main/java/com/repill/backend/member/entity/Member.java
@@ -28,7 +28,8 @@ public class Member extends BaseEntity {
     private Integer level;
 
     @Enumerated(EnumType.STRING)
-    private Rank rank;
+    @Column(name = "member_rank")
+    private Rank memberRank;
 
     private Integer participantCount;
 }


### PR DESCRIPTION
## 작업 내용

> Member 엔티티의 rank 필드를 memberRank로 필드명 변경.

## 참고 사항

> 

## 연관 이슈

> close #11 


<br>
