### PR TITLE
✨ Feat: 사용자 주소 등록 API 구현

### DIFF
--- a/src/main/java/com/repill/backend/member/controller/MemberController.java
+++ b/src/main/java/com/repill/backend/member/controller/MemberController.java
@@ -21,19 +21,24 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @Operation(summary = "회원 정보 조회 API (마이페이지)",
-            description = "현재 사용자의 회원 정보를 조회합니다.")
+    @Operation(summary = "회원 정보 조회 API (마이페이지)", description = "현재 사용자의 회원 정보를 조회합니다.")
     @GetMapping
     public ApiResponse<MemberResponse.memberInfoResponse> createMedicine(@AuthUser Long memberId) {
         MemberResponse.memberInfoResponse result = memberService.getMemberInfo(memberId);
         return ApiResponse.onSuccess(result);
     }
 
-    @Operation(summary = "폐기한 약품 종류 통계 (MY 페이지 하단 차트) API",
-            description = "본인이 그동안 폐기했던 약품 종류의 통계를 조회합니다.")
+    @Operation(summary = "폐기한 약품 종류 통계 (MY 페이지 하단 차트) API", description = "본인이 그동안 폐기했던 약품 종류의 통계를 조회합니다.")
     @GetMapping("/discard-medicines")
     public ApiResponse<MemberResponse.StatisticsByTypeOfDrug> getMedicineTypeStatistics(@AuthUser Long memberId) {
         MemberResponse.StatisticsByTypeOfDrug result = memberService.getMedicineTypeStatistics(memberId);
         return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "나의 위치 등록 API", description = "사용자의 위치를 저장합니다.")
+    @PostMapping("/api/members/location")
+    public ApiResponse<String> saveLocation(@AuthUser Long memberId, String location) {
+        memberService.saveLocation(memberId, location);
+        return ApiResponse.onSuccess("위치 설정이 완료되었습니다.");
     }
 }

--- a/src/main/java/com/repill/backend/member/entity/MemberLocation.java
+++ b/src/main/java/com/repill/backend/member/entity/MemberLocation.java
@@ -25,4 +25,13 @@ public class MemberLocation {
     private Double latitude;
 
     private Double longitude;
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public MemberLocation(Member member, String location) {
+        this.member = member;
+        this.location = location;
+    }
 }

--- a/src/main/java/com/repill/backend/member/memberService/MemberService.java
+++ b/src/main/java/com/repill/backend/member/memberService/MemberService.java
@@ -13,9 +13,12 @@ import com.repill.backend.medicine.repository.MedicineTypeJpaRepository;
 import com.repill.backend.member.converter.MemberConverter;
 import com.repill.backend.member.dto.MemberResponse;
 import com.repill.backend.member.entity.Member;
+import com.repill.backend.member.entity.MemberLocation;
+import com.repill.backend.member.repository.MemberLocationRepository;
 import com.repill.backend.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -29,6 +32,7 @@ public class MemberService {
     private final DiscardRecordRepository discardRecordRepository;
     private final DiscardRecordJpaRepository discardRecordJpaRepository;
     private final MedicineTypeJpaRepository medicineTypeJpaRepository;
+    private final MemberLocationRepository memberLocationRepository;
 
     public MemberResponse.memberInfoResponse getMemberInfo(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new RePillClientException(ErrorStatus.USER_NOT_FOUND));
@@ -65,5 +69,19 @@ public class MemberService {
         List<DiscardRecord> discardList =  discardRecordJpaRepository.findAllByMember(member);
         List<MemberResponse.typeOfMedecine> DiscardMedicineList = getDiscardMedecineList(memberId,discardList);
         return MemberConverter.toStatisticsByTypeOfMedecine(member, DiscardMedicineList);
+    }
+
+    @Transactional
+    public void saveLocation(Long memberId,String location){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new TestHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Optional<MemberLocation> getMemberLocation = memberLocationRepository.findByMember(member);
+
+        if(getMemberLocation.isPresent()){
+            getMemberLocation.get().setLocation(location);
+        }else{
+            MemberLocation newMemberLocation = new MemberLocation(member, location);
+            memberLocationRepository.save(newMemberLocation);
+        }
     }
 }

--- a/src/main/java/com/repill/backend/member/repository/MemberLocationRepository.java
+++ b/src/main/java/com/repill/backend/member/repository/MemberLocationRepository.java
@@ -1,0 +1,11 @@
+package com.repill.backend.member.repository;
+
+import com.repill.backend.member.entity.Member;
+import com.repill.backend.member.entity.MemberLocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberLocationRepository extends JpaRepository<MemberLocation, Long> {
+    Optional<MemberLocation> findByMember(Member member);
+}


### PR DESCRIPTION
## 작업 내용

> 사용자 주소 등록 API를 구현했습니다.
> 해당 사용자의 MemberLocation 객체가 이미 존재하는 경우 location 필드의 값을 업데이트하며, 존재하지 않는 경우 MemberLocation 객체를 생성합니다.

## 참고 사항

> 

## 연관 이슈

> 이 PR과 연관된 이슈 번호를 작성하세요. 예) close #24 


<br>
